### PR TITLE
GID-150 | Add content server configuration options and change specified playlist routes to use configured server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,13 +29,17 @@ DBP_USERS_DATABASE=dbp_users
 DBP_USERS_USERNAME=root
 DBP_USERS_PASSWORD=
 
-# V2 Database connections 
-# 
+# V2 Database connections
+#
 DBP_USERS_V2_HOST=127.0.0.1
 DBP_USERS_V2_PORT=3306
 DBP_USERS_V2_DATABASE=dbp_users_v2
 DBP_USERS_V2_USERNAME=root
 DBP_USERS_V2_PASSWORD=
+
+# Content upstream URL
+CONTENT_URL=https://dbp.test/api/
+CONTENT_KEY=
 
 # Drivers
 # -----------------------------------

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use GuzzleHttp\Client;
 
 class PlaylistsController extends APIController
 {
@@ -1194,31 +1195,61 @@ class PlaylistsController extends APIController
     {
         $filesets = Arr::pluck(DB::connection('dbp_users')
             ->select('select DISTINCT(fileset_id) from playlist_items where playlist_id = ?', [$playlist_id]), 'fileset_id');
+        $fileset_text_info = array();
 
-        $filesets_hashes = DB::connection('dbp')
-            ->table('bible_filesets')
-            ->select(['hash_id', 'id'])
-            ->whereIn('id', $filesets)->get();
+        $config = config('services.content');
 
-        $hashes_bibles = DB::connection('dbp')
-            ->table('bible_fileset_connections')
-            ->select(['hash_id', 'bible_id'])
-            ->whereIn('hash_id', $filesets_hashes->pluck('hash_id'))->get();
+        // if configured to use content server
+        if (!empty($config['ur'])) {
+          $client = new Client();
+          $res = $client->get($config['url'] . 'bibles/filesets/'.
+            join(',',$filesets).'/playlist?v=4&key=' . $config['key']);
+          $filesets_hashes = collect(json_decode($res->getBody() . ''));
 
-        $text_filesets = DB::connection('dbp')
-            ->table('bible_fileset_connections as fc')
-            ->join('bible_filesets as f', 'f.hash_id', '=', 'fc.hash_id')
-            ->select(['f.*', 'fc.bible_id'])
-            ->where('f.set_type_code', 'text_plain')
-            ->whereIn('fc.bible_id', $hashes_bibles->pluck('bible_id'))->get()->groupBy('bible_id');
+          $fileset_text_info = array();
+          foreach ($filesets as $fileset) {
+              // f data
+              $fileset_text_info[$fileset] = $filesets_hashes[$fileset];
+          }
+        } else {
+          // else use local data
 
+          // lookup filesets and get hashes
+          // map id to hash_id
+          $filesets_hashes = DB::connection('dbp')
+              ->table('bible_filesets')
+              ->select(['hash_id', 'id'])
+              ->whereIn('id', $filesets)->get();
 
-        $fileset_text_info = $filesets_hashes->pluck('hash_id', 'id');
-        $bible_hash = $hashes_bibles->pluck('bible_id', 'hash_id');
+          // convert fileset hashes into bible_ids
+          // map hash_id to bible_id
+          $hashes_bibles = DB::connection('dbp')
+              ->table('bible_fileset_connections')
+              ->select(['hash_id', 'bible_id'])
+              ->whereIn('hash_id', $filesets_hashes->pluck('hash_id'))->get();
 
-        foreach ($filesets as $fileset) {
-            $bible_id = $bible_hash[$fileset_text_info[$fileset]];
-            $fileset_text_info[$fileset] = $text_filesets[$bible_id];
+          // convert bible_ids into text filesets + bible_ids
+          // map bible_id to f data
+          $text_filesets = DB::connection('dbp')
+              ->table('bible_fileset_connections as fc')
+              ->join('bible_filesets as f', 'f.hash_id', '=', 'fc.hash_id')
+              ->select(['f.*', 'fc.bible_id'])
+              ->where('f.set_type_code', 'text_plain')
+              ->whereIn('fc.bible_id', $hashes_bibles->pluck('bible_id'))->get()->groupBy('bible_id');
+
+          // create fileset lookup to hash
+          $fileset_text_info = $filesets_hashes->pluck('hash_id', 'id');
+          // create hash lookup to id
+          $bible_hash = $hashes_bibles->pluck('bible_id', 'hash_id');
+
+          // build fileset_text_info from fileset
+          foreach ($filesets as $fileset) {
+              // need text
+              // get bible_id for this fileset
+              $bible_id = $bible_hash[$fileset_text_info[$fileset]];
+              // fetch text for bible_id
+              $fileset_text_info[$fileset] = $text_filesets[$bible_id];
+          }
         }
         return $fileset_text_info;
     }

--- a/app/Http/Controllers/User/SwaggerDocsController.php
+++ b/app/Http/Controllers/User/SwaggerDocsController.php
@@ -27,7 +27,9 @@ class SwaggerDocsController extends Controller
 
     public function swaggerDocsGen($version)
     {
-        define('API_URL_DOCS', config('app.api_url'));
+        if (!defined('API_URL_DOCS')) {
+            define('API_URL_DOCS', config('app.api_url'));
+        }
         $swagger = cacheRemember('OAS', [$version], now()->addDay(), function () use ($version) {
             $swagger = \OpenApi\scan(app_path());
             $swagger->tags  = $this->swaggerVersionTags($swagger->tags, $version);

--- a/config/services.php
+++ b/config/services.php
@@ -74,11 +74,15 @@ return [
         'url' => env('ARCLIGHT_API_URL', 'https://api.arclight.org/v2/')
     ],
 
+    'content' => [
+        'url' => env('CONTENT_URL'),
+        'key' => env('CONTENT_KEY')
+    ],
+
     // Testing
 
     'loaderIo' => [
         'key' => env('LOADER_IO')
     ]
-
 
 ];

--- a/tests/Integration/ApiV4Test.php
+++ b/tests/Integration/ApiV4Test.php
@@ -19,6 +19,7 @@ class ApiV4Test extends TestCase
     protected function setUp():void
     {
         parent::setUp();
+        // insert into user_keys (name,user_id,`key`) values ('test-key',1,'phpunitTestKey');
         $this->key    = Key::where('name', 'test-key')->first()->key;
         $this->params = ['v' => 4, 'key' => $this->key, 'pretty'];
 

--- a/tests/Integration/PlaylistRoutesTest.php
+++ b/tests/Integration/PlaylistRoutesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Http\Controllers\Playlist\PlaylistController;
+
+class PlaylistRoutesTest extends ApiV4Test
+{
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_playlists.show
+     * @category Route Path: https://api.dbp.test/playlists/?v=4&key={key}
+     * @see      PlaylistsController::show
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function show()
+    {
+        //
+        $test_playlist_id = 472982;
+        $path = route('v4_playlists.show', array_merge($this->params, [
+            'playlist_id'    => $test_playlist_id,
+        ]));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+        $result = collect(json_decode($response->getContent()));
+        $this->assertEquals($result->count(), 13); // has 13 fields...
+        $this->assertEquals($result['id'], $test_playlist_id);
+        //$this->assertEquals($result->user->id, '1223628');
+    }
+}


### PR DESCRIPTION
- adds content service configuration option
- `playlistController::getPlaylistTextFilesets` pulls `show_text` from content server (if configured so)
- `playlistController::translate` pulls audio/bible data from content server (if configured so)
- `playlistController::getPlaylist` pulls bible IDs from content server (if configured so)
- update PlaylistItem model's getVerseText to pull verses from content server if configured
  - uses cache to avoid 429s
  - updates the following be content server friendly:
    -  `playlistController::showText`
    - `playlistController::getPlaylists`
    - but not `playlistController::show`(since we pass in filesets (IDs))
  - now requires #4 to work
- add integration unit test for `playlist.show`
