### PR TITLE
GID-157 | [content-side] Add new route to get fileset verses (featured playlists for plans)

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -126,6 +126,22 @@ class BibleFileSetsController extends APIController
         return $this->reply($fileset_chapters, [], $transaction_id ?? '');
     }
 
+    public function showFeatured($id = null, $asset_id = null, $set_type_code = null, $cache_key = 'bible_filesets_show2')
+    {
+        // get fileset
+        $fileset = BibleFileset::where('id', $id)->first();
+        // load text_plain for this bible
+        $text_fileset = $fileset->bible->first()->filesets->where('set_type_code', 'text_plain')->first();
+        // back up hash_id
+        $hash_id = $text_fileset->hash_id;
+        // copy text_fileset
+        $text_fileset_copy = json_decode(json_encode($text_fileset));
+        // expose hash_id
+        $text_fileset_copy->hash_id = $hash_id;
+        // return text_plain for this bible including hash_id
+        return $this->reply($text_fileset_copy, [], '');
+    }
+
     private function signedPath($bible, $fileset, $fileset_chapter)
     {
         switch ($fileset->set_type_code) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,6 +35,7 @@ Route::name('v4_filesets.podcast')->get('bibles/filesets/{fileset_id}/podcast', 
 Route::name('v4_filesets.download')->get('bibles/filesets/{fileset_id}/download',  'Bible\BibleFileSetsController@download');
 Route::name('v4_filesets.copyright')->get('bibles/filesets/{fileset_id}/copyright', 'Bible\BibleFileSetsController@copyright');
 Route::name('v4_filesets.show')->get('bibles/filesets/{fileset_id?}',              'Bible\BibleFileSetsController@show');
+Route::name('v4_filesets.showFeatured')->get('bibles/filesets/{fileset_id}/verses',              'Bible\BibleFileSetsController@showFeatured');
 Route::name('v4_filesets.update')->put('bibles/filesets/{fileset_id}',             'User\Dashboard\BibleFilesetsManagementController@update');
 Route::name('v4_filesets.store')->post('bibles/filesets',             'User\Dashboard\BibleFilesetsManagementController@store');
 Route::name('v4_filesets.books')->get('bibles/filesets/{fileset_id}/books',        'Bible\BooksController@show');


### PR DESCRIPTION
Added route `bibles/filesets/{fileset_id}/verses` for content server to provide the information we need from the content database for `getVerseText`